### PR TITLE
added quotedStringSupport to prevent issues

### DIFF
--- a/src/commands/Regex/removeregex.js
+++ b/src/commands/Regex/removeregex.js
@@ -65,7 +65,7 @@ module.exports = class extends Command {
 		const inexistentChunks = chunk(inexistent, 20);
 		for (const chunky of inexistentChunks) {
 			display.addPage(
-				template => template.setTitle(`The following${chunky.length !== 1 ? `__${chunky.length}__` : ""} regex${chunky.length === 1 ? " was" : "es were"} not existent in your highlight list`)
+				template => template.setTitle(`The following${chunky.length !== 1 ? ` __${chunky.length}__` : ""} regex${chunky.length === 1 ? " was" : "es were"} not existent in your highlight list`)
 					.setDescription(chunky.map(regex => `• ${escapeMarkdown(regex)}`).join("\n"))
 			);
 		}

--- a/src/commands/Word/addword.js
+++ b/src/commands/Word/addword.js
@@ -11,7 +11,6 @@ module.exports = class extends Command {
 			usage: "<Word:str> [...]",
 			usageDelim: " ",
 			aliases: ["aword", "aw", "addwords", "awords", "aws", "addw"],
-			quotedStringSupport: true,
 		});
 
 		this.customizeResponse("Word",

--- a/src/commands/Word/addword.js
+++ b/src/commands/Word/addword.js
@@ -11,6 +11,7 @@ module.exports = class extends Command {
 			usage: "<Word:str> [...]",
 			usageDelim: " ",
 			aliases: ["aword", "aw", "addwords", "awords", "aws", "addw"],
+			quotedStringSupport: true,
 		});
 
 		this.customizeResponse("Word",

--- a/src/commands/Word/removeword.js
+++ b/src/commands/Word/removeword.js
@@ -11,6 +11,7 @@ module.exports = class extends Command {
 			usage: "<Word:str> [...]",
 			usageDelim: " ",
 			aliases: ["rword", "rw", "removewords", "rwords", "rws", "removew"],
+			quotedStringSupport: true,
 		});
 		this.customizeResponse("Word",
 			new MessageEmbed()
@@ -65,7 +66,7 @@ module.exports = class extends Command {
 		const inexistentChunks = chunk(inexistent, 20);
 		for (const chunky of inexistentChunks) {
 			display.addPage(
-				template => template.setTitle(`The following${chunky.length !== 1 ? `__${chunky.length}__` : ""} word${chunky.length === 1 ? " was" : "s were"} not existent in your highlight list`)
+				template => template.setTitle(`The following${chunky.length !== 1 ? ` __${chunky.length}__` : ""} word${chunky.length === 1 ? " was" : "s were"} not existent in your highlight list`)
 					.setDescription(chunky.map(word => `• ${word}`).join("\n"))
 			);
 		}

--- a/src/commands/Word/removeword.js
+++ b/src/commands/Word/removeword.js
@@ -11,7 +11,6 @@ module.exports = class extends Command {
 			usage: "<Word:str> [...]",
 			usageDelim: " ",
 			aliases: ["rword", "rw", "removewords", "rwords", "rws", "removew"],
-			quotedStringSupport: true,
 		});
 		this.customizeResponse("Word",
 			new MessageEmbed()


### PR DESCRIPTION
I added quotedStringSupport to prevent issues when trying to remove words with `"` at the end and beginning of a word trigger.