### PR TITLE
fix: typo in `block` remove command

### DIFF
--- a/src/commands/Highlight/block.ts
+++ b/src/commands/Highlight/block.ts
@@ -127,7 +127,7 @@ export default class extends Command {
 		}
 
 		if (removedChannels.size)
-			embed.addField(`The following ${pluralize(changes[1].length, 'channel has', 'channels have')} been blocked`, `- ${[...removedChannels].map((channel) => `${channel} — ${channel.id}`).join('\n- ')}`);
+			embed.addField(`The following ${pluralize(changes[1].length, 'channel has', 'channels have')} been unblocked`, `- ${[...removedChannels].map((channel) => `${channel} — ${channel.id}`).join('\n- ')}`);
 
 		if (!changes[0].length && !changes[1].length) embed.setDescription('No changes have been made to your block list..');
 


### PR DESCRIPTION
This fixes a typo in the remove command, where it would say "_The following channel(s) ha(s/ve) been blocked._".